### PR TITLE
fix(parser)!: make styles composable with a base style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/bfhbhh28bi48q1sbmzj5wzia0rwsxjjj-ansi-to-tui-nextest-8.0.1

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+style_edition = "2024"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@
 //! - Colors: named (3/4-bit, 8/16-color), indexed (8-bit, 256-color), and truecolor (24-bit RGB).
 //! - Optional `zero-copy` API that borrows from the input.
 //!
+//! Whatever the input returns to its default is left unset in the produced [`Style`][Style],
+//! rather than spelled out as [`Color::Reset`][Color] and [`Modifier`][Modifier] removals, so the
+//! text inherits it from whatever it is drawn onto.
+//!
 //! # Supported Color Codes
 //!
 //! | Color Mode                  | Supported | SGR Example              | Ratatui `Color` Example |

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,39 +34,50 @@ struct AnsiStates {
     pub style: Style,
 }
 
+/// The style with the given modifiers returned to their default.
+///
+/// Unlike [`Style::remove_modifier`] this does not ask for them to be removed from the style we
+/// are applied to, it just stops asking for them ourselves.
+fn unset_modifier(style: Style, modifier: Modifier) -> Style {
+    Style {
+        add_modifier: style.add_modifier.difference(modifier),
+        ..style
+    }
+}
+
 impl From<AnsiStates> for ratatui_core::style::Style {
     fn from(states: AnsiStates) -> Self {
         let mut style = states.style;
         if states.items.is_empty() {
             // https://github.com/uttarayan21/ansi-to-tui/issues/40
             // [m should be treated as a reset as well
-            style = Style::reset();
+            style = Style::new();
         }
         for item in states.items {
             match item.code {
-                AnsiCode::Reset => style = Style::reset(),
+                AnsiCode::Reset => style = Style::new(),
                 AnsiCode::Bold => style = style.add_modifier(Modifier::BOLD),
                 AnsiCode::Faint => style = style.add_modifier(Modifier::DIM),
                 AnsiCode::Normal => {
-                    style = style.remove_modifier(Modifier::BOLD | Modifier::DIM);
+                    style = unset_modifier(style, Modifier::BOLD | Modifier::DIM);
                 }
                 AnsiCode::Italic => style = style.add_modifier(Modifier::ITALIC),
-                AnsiCode::NotItalic => style = style.remove_modifier(Modifier::ITALIC),
+                AnsiCode::NotItalic => style = unset_modifier(style, Modifier::ITALIC),
                 AnsiCode::Underline => style = style.add_modifier(Modifier::UNDERLINED),
-                AnsiCode::UnderlineOff => style = style.remove_modifier(Modifier::UNDERLINED),
+                AnsiCode::UnderlineOff => style = unset_modifier(style, Modifier::UNDERLINED),
                 AnsiCode::SlowBlink => style = style.add_modifier(Modifier::SLOW_BLINK),
                 AnsiCode::RapidBlink => style = style.add_modifier(Modifier::RAPID_BLINK),
                 AnsiCode::BlinkOff => {
-                    style = style.remove_modifier(Modifier::SLOW_BLINK | Modifier::RAPID_BLINK)
+                    style = unset_modifier(style, Modifier::SLOW_BLINK | Modifier::RAPID_BLINK)
                 }
                 AnsiCode::Reverse => style = style.add_modifier(Modifier::REVERSED),
-                AnsiCode::InvertOff => style = style.remove_modifier(Modifier::REVERSED),
+                AnsiCode::InvertOff => style = unset_modifier(style, Modifier::REVERSED),
                 AnsiCode::Conceal => style = style.add_modifier(Modifier::HIDDEN),
-                AnsiCode::Reveal => style = style.remove_modifier(Modifier::HIDDEN),
+                AnsiCode::Reveal => style = unset_modifier(style, Modifier::HIDDEN),
                 AnsiCode::CrossedOut => style = style.add_modifier(Modifier::CROSSED_OUT),
-                AnsiCode::CrossedOutOff => style = style.remove_modifier(Modifier::CROSSED_OUT),
-                AnsiCode::DefaultForegroundColor => style = style.fg(Color::Reset),
-                AnsiCode::DefaultBackgroundColor => style = style.bg(Color::Reset),
+                AnsiCode::CrossedOutOff => style = unset_modifier(style, Modifier::CROSSED_OUT),
+                AnsiCode::DefaultForegroundColor => style = Style { fg: None, ..style },
+                AnsiCode::DefaultBackgroundColor => style = Style { bg: None, ..style },
                 AnsiCode::SetForegroundColor => {
                     if let Some(color) = item.color {
                         style = style.fg(color)
@@ -128,8 +139,7 @@ fn line(style: Style) -> impl Fn(&[u8]) -> IResult<&[u8], (Line<'static>, Style)
         let mut spans = Vec::new();
         let mut last = style;
         while let Ok((s, span)) = span(last)(text) {
-            // Since reset now tracks seperately we can skip the reset check
-            last = last.patch(span.style);
+            last = span.style;
 
             if !span.content.is_empty() {
                 spans.push(span);
@@ -153,7 +163,7 @@ fn line_fast(style: Style) -> impl Fn(&[u8]) -> IResult<&[u8], (Line<'_>, Style)
         let mut spans = Vec::new();
         let mut last = style;
         while let Ok((s, span)) = span_fast(last)(text) {
-            last = last.patch(span.style);
+            last = span.style;
             // If the spans is empty then it might be possible that the style changes
             // but there is no text change
             if !span.content.is_empty() {
@@ -190,7 +200,7 @@ fn span(last: Style) -> impl Fn(&[u8]) -> IResult<&[u8], Span<'static>, nom::err
         .parse(s)?;
 
         if let Some(style) = style.flatten() {
-            last = last.patch(style);
+            last = style;
         }
 
         Ok((s, Span::styled(text.to_owned(), last)))
@@ -218,13 +228,18 @@ fn span_fast(last: Style) -> impl Fn(&[u8]) -> IResult<&[u8], Span<'_>, nom::err
         .parse(s)?;
 
         if let Some(style) = style.flatten() {
-            last = last.patch(style);
+            last = style;
         }
 
         Ok((s, Span::styled(text, last)))
     }
 }
 
+/// The style an SGR code yields when applied on top of `style`.
+///
+/// The result already carries everything that is still in effect, so callers replace their current
+/// style with it rather than patching it in — patching would keep fields the code left unset on
+/// purpose.
 #[allow(clippy::type_complexity)]
 fn style(
     style: Style,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -161,8 +161,8 @@ fn unknown_sgr_codes_are_ignored_and_chained_items_still_apply() {
 fn empty_sgr_sequence_is_treated_as_reset() {
     let string = b"\x1b[32mGREEN\x1b[mFOO\nFOO";
     let output = Text::from(vec![
-        Line::from(vec!["GREEN".green(), Span::styled("FOO", Style::reset())]),
-        Line::from(Span::styled("FOO", Style::reset())),
+        Line::from(vec!["GREEN".green(), Span::raw("FOO")]),
+        Line::from(Span::raw("FOO")),
     ]);
     test_both(string, output);
 }
@@ -178,20 +178,14 @@ fn chained_sgr_items_in_single_escape_sequence_are_applied_in_order() {
 fn does_not_emit_empty_spans_for_style_only_changes() {
     // Yellow -> Red -> Green -> "Hello" -> Reset -> "World"
     let bytes: Vec<u8> = b"\x1b[33m\x1b[31m\x1b[32mHello\x1b[0mWorld".to_vec();
-    let output = Text::from(Line::from(vec![
-        "Hello".green(),
-        Span::styled("World", Style::reset()),
-    ]));
+    let output = Text::from(Line::from(vec!["Hello".green(), Span::raw("World")]));
     test_both(bytes, output);
 }
 
 #[test]
 fn sgr_0_resets_style() {
     let string = "\x1b[33mA\x1b[0mB";
-    let output = Text::from(Line::from(vec![
-        "A".yellow(),
-        Span::styled("B", Style::reset()),
-    ]));
+    let output = Text::from(Line::from(vec!["A".yellow(), Span::raw("B")]));
     test_both(string, output);
 }
 
@@ -201,7 +195,7 @@ fn sgr_1_and_22_toggle_bold() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "bold".bold(),
-        ", not anymore".not_bold().not_dim(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -212,7 +206,7 @@ fn sgr_2_and_22_toggle_faint() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "faint".dim(),
-        ", not anymore".not_bold().not_dim(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -225,7 +219,7 @@ fn sgr_3_and_23_toggle_italic() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "italic".italic(),
-        ", not anymore".not_italic(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -238,7 +232,7 @@ fn sgr_4_and_24_toggle_underline() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "underlined".underlined(),
-        ", not anymore".not_underlined(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -251,7 +245,7 @@ fn sgr_5_and_25_toggle_slow_blink() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "blinking".slow_blink(),
-        ", not anymore".not_slow_blink().not_rapid_blink(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -262,7 +256,7 @@ fn sgr_6_and_25_toggle_rapid_blink() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "rapid".rapid_blink(),
-        ", not anymore".not_slow_blink().not_rapid_blink(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -275,7 +269,7 @@ fn sgr_7_and_27_toggle_reverse_video() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "reversed".reversed(),
-        ", not anymore".not_reversed(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -288,7 +282,7 @@ fn sgr_8_and_28_toggle_conceal() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "concealed".hidden(),
-        ", not anymore".not_hidden(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -301,7 +295,7 @@ fn sgr_9_and_29_toggle_crossed_out() {
     let output = Text::from(Line::from(vec![
         Span::raw("not, "),
         "crossed".crossed_out(),
-        ", not anymore".not_crossed_out(),
+        Span::raw(", not anymore"),
     ]));
     test_both(bytes, output);
 }
@@ -433,10 +427,7 @@ fn parses_4bit_bright_colors_and_backgrounds() {
 #[test]
 fn sgr_31_and_39_toggle_foreground_color() {
     let bytes: Vec<u8> = b"\x1b[31;1mred\x1b[39mdefault".to_vec();
-    let output = Text::from(Line::from(vec![
-        "red".red().bold(),
-        "default".bold().fg(Color::Reset),
-    ]));
+    let output = Text::from(Line::from(vec!["red".red().bold(), "default".bold()]));
     test_both(bytes, output);
 }
 
@@ -445,7 +436,7 @@ fn sgr_44_and_49_toggle_background_color() {
     let bytes: Vec<u8> = b"\x1b[44;1mblue-bg\x1b[49mdefault".to_vec();
     let output = Text::from(Line::from(vec![
         "blue-bg".on_blue().bold(),
-        "default".bold().bg(Color::Reset),
+        "default".bold(),
     ]));
     test_both(bytes, output);
 }
@@ -507,20 +498,83 @@ fn carries_style_across_lines_and_handles_resets() {
     let output = Text::from(vec![
         Line::from(vec![
             "* ".green(),
-            Span::styled("Running before-startup command ", Style::reset()),
-            Span::styled("command", Style::reset()).bold(),
-            Span::styled("=make my-simple-package.cabal", Style::reset()),
+            Span::raw("Running before-startup command "),
+            "command".bold(),
+            Span::raw("=make my-simple-package.cabal"),
         ]),
         Line::from(vec![
-            Span::styled("* ", Style::reset()).green(),
-            Span::styled("$ make my-simple-package.cabal", Style::reset()),
+            "* ".green(),
+            Span::raw("$ make my-simple-package.cabal"),
         ]),
-        Line::from(vec![Span::styled(
-            "Build profile: -w ghc-9.0.2 -O1",
-            Style::reset(),
-        )]),
+        Line::from(vec![Span::raw("Build profile: -w ghc-9.0.2 -O1")]),
     ]);
     test_both(bytes, output);
+}
+
+#[test]
+fn leaves_everything_unset_on_reset() {
+    let bytes = "\x1b[1;33;44mA\x1b[0mB";
+    let output = Text::from(Line::from(vec![
+        "A".yellow().on_blue().bold(),
+        Span::raw("B"),
+    ]));
+    test_both(bytes, output);
+}
+
+#[test]
+fn leaves_foreground_unset_on_default_foreground() {
+    let bytes = "\x1b[33;44mA\x1b[39mB";
+    let output = Text::from(Line::from(vec!["A".yellow().on_blue(), "B".on_blue()]));
+    test_both(bytes, output);
+}
+
+#[test]
+fn leaves_background_unset_on_default_background() {
+    let bytes = "\x1b[33;44mA\x1b[49mB";
+    let output = Text::from(Line::from(vec!["A".yellow().on_blue(), "B".yellow()]));
+    test_both(bytes, output);
+}
+
+#[test]
+fn keeps_the_colors_the_input_asks_for() {
+    let bytes = "\x1b[0mA\x1b[40mB";
+    let output = Text::from(Line::from(vec![Span::raw("A"), "B".on_black()]));
+    test_both(bytes, output);
+}
+
+#[test]
+fn base_style_survives_a_reset() {
+    let base = Style::new().fg(Color::Green).bold();
+    test_patched_onto(
+        base,
+        "\x1b[31mA\x1b[0mB",
+        vec![Style::new().fg(Color::Red).bold(), base],
+    );
+}
+
+#[test]
+fn base_style_survives_a_modifier_being_switched_off() {
+    let base = Style::new().italic();
+    test_patched_onto(base, "\x1b[3mA\x1b[23mB", vec![Style::new().italic(), base]);
+}
+
+/// Assert the span styles the input produces once patched onto `base`.
+#[track_caller]
+fn test_patched_onto(base: Style, bytes: impl AsRef<[u8]>, expected: Vec<Style>) {
+    let bytes = bytes.as_ref();
+
+    let patched = |text: &Text| -> Vec<Style> {
+        text.lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .map(|span| base.patch(span.style))
+            .collect()
+    };
+
+    #[cfg(feature = "zero-copy")]
+    assert_eq!(patched(&bytes.to_text().unwrap()), expected);
+
+    assert_eq!(patched(&bytes.into_text().unwrap()), expected);
 }
 
 #[track_caller]


### PR DESCRIPTION
Currently reset-like codes (SGR 0 etc) result in Color::Reset styles and/or explicitly disabled bold/italics etc. That is correct when rendering the resulting Text in a plain terminal, but breaks composability in ratatui, which might be rendering the text in a widget that already has a base style. The ANSI to Text transformation also means that we go from a global style state to scoped styling information. In that context reset should just translate to "do not apply any extra styles" rather than "render this with the terminal's default style".

Context: I'm trying to render jj's diff output onto a widget that has a background color, and the resets poke through it, resetting the color all the way back to my terminals default. I hope this makes sense and I'm not just holding it wrong :sweat_smile: 

This also comes with update for crossbeam-epoch which has a CI-failing RUSTSEC-2026-0204, and anyhow with RUSTSEC-2026-0190. Both dev-dependencies only. lru also has RUSTSEC-2026-0253 but its update via ratatui-core 0.1.2 would require raising the MSRV and I'm not familiar with the policies for that. Happy to update the PR if the raise is fine.

BREAKING CHANGE: Sequences that return the terminal to its defaults now leave the style unset instead of producing Color::Reset and modifier removals. Callers that want the terminal's defaults have to put them into the base style they render with.